### PR TITLE
Component/copy button

### DIFF
--- a/src/app/components/CopyButton/CopyButton.stories.tsx
+++ b/src/app/components/CopyButton/CopyButton.stories.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import CopyButton from './CopyButton';
+
+export default {
+  title: 'Component/CopyButton',
+  component: CopyButton,
+};
+
+export const Regular = (): JSX.Element => (
+  <CopyButton copyData={() => console.log('clicked!')} />
+);

--- a/src/app/components/CopyButton/CopyButton.stories.tsx
+++ b/src/app/components/CopyButton/CopyButton.stories.tsx
@@ -7,5 +7,5 @@ export default {
 };
 
 export const Regular = (): JSX.Element => (
-  <CopyButton copyData={() => console.log('clicked!')} />
+  <CopyButton copyText={'hello there!'} />
 );

--- a/src/app/components/CopyButton/CopyButton.tsx
+++ b/src/app/components/CopyButton/CopyButton.tsx
@@ -31,13 +31,22 @@ export default function CopyButton({ copyText }: CopyButtonProps): JSX.Element {
   };
 
   return (
-    <CopyToClipboardButton onClick={handleCopyClick}>
-      <span>
-        {isCopied ? 'Beurteilungen kopiert' : 'Beurteilungen kopieren'}
-      </span>
-    </CopyToClipboardButton>
+    <>
+      <Breakline />
+      <CopyToClipboardButton onClick={handleCopyClick}>
+        <span>
+          {isCopied ? 'Beurteilungen kopiert' : 'Beurteilungen kopieren'}
+        </span>
+      </CopyToClipboardButton>
+    </>
   );
 }
+
+const Breakline = styled.hr`
+  width: 80%;
+  border-top: 3px double var(--color-stroke);
+  height: 0.25rem;
+`;
 
 const CopyToClipboardButton = styled(Button)`
   width: 50%;

--- a/src/app/components/CopyButton/CopyButton.tsx
+++ b/src/app/components/CopyButton/CopyButton.tsx
@@ -3,16 +3,37 @@ import styled from 'styled-components';
 import Button from '../Button/Button';
 
 type CopyButtonProps = {
-  copyData: () => void;
+  copyText: string;
 };
 
-export default function CopyButton({ copyData }: CopyButtonProps): JSX.Element {
+export default function CopyButton({ copyText }: CopyButtonProps): JSX.Element {
   const [isCopied, setIsCopied] = useState(false);
 
+  async function copyTextToClipboard(text: string) {
+    if ('clipboard' in navigator) {
+      return await navigator.clipboard.writeText(text);
+    } else {
+      return document.execCommand('copy', true, text);
+    }
+  }
+
+  const handleCopyClick = () => {
+    copyTextToClipboard(copyText)
+      .then(() => {
+        setIsCopied(true);
+        setTimeout(() => {
+          setIsCopied(false);
+        }, 1500);
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  };
+
   return (
-    <CopyToClipboardButton onClick={copyData}>
+    <CopyToClipboardButton onClick={handleCopyClick}>
       <span>
-        {isCopied ? 'Beurteilungen exportieren' : 'Beurteilungen kopiert'}
+        {isCopied ? 'Beurteilungen kopiert' : 'Beurteilungen kopieren'}
       </span>
     </CopyToClipboardButton>
   );
@@ -21,4 +42,5 @@ export default function CopyButton({ copyData }: CopyButtonProps): JSX.Element {
 const CopyToClipboardButton = styled(Button)`
   width: 50%;
   padding: 1rem 0;
+  margin-top: 2rem;
 `;

--- a/src/app/components/CopyButton/CopyButton.tsx
+++ b/src/app/components/CopyButton/CopyButton.tsx
@@ -1,0 +1,24 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import Button from '../Button/Button';
+
+type CopyButtonProps = {
+  copyData: () => void;
+};
+
+export default function CopyButton({ copyData }: CopyButtonProps): JSX.Element {
+  const [isCopied, setIsCopied] = useState(false);
+
+  return (
+    <CopyToClipboardButton onClick={copyData}>
+      <span>
+        {isCopied ? 'Beurteilungen exportieren' : 'Beurteilungen kopiert'}
+      </span>
+    </CopyToClipboardButton>
+  );
+}
+
+const CopyToClipboardButton = styled(Button)`
+  width: 50%;
+  padding: 1rem 0;
+`;

--- a/src/app/pages/ClassOverview/ClassOverview.tsx
+++ b/src/app/pages/ClassOverview/ClassOverview.tsx
@@ -2,13 +2,16 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import Button from '../../components/Button/Button';
 import Card from '../../components/Card/Card';
+import CopyButton from '../../components/CopyButton/CopyButton';
 import Form from '../../components/Form/Form';
 import Header from '../../components/Header/Header';
 import usePupils from '../../hooks/usePupils';
+import type { Evaluation, Pupil } from '../../types/types';
 
 export default function ClassOverview(): JSX.Element {
   const { pupils, addPupil, deletePupil } = usePupils();
   const [isFormShown, setIsFormShown] = useState(false);
+  const dataToCopy = getTextToCopy(pupils);
 
   function handleFormSubmit(pupil: {
     name: string;
@@ -17,6 +20,34 @@ export default function ClassOverview(): JSX.Element {
   }) {
     addPupil(pupil);
     setIsFormShown(false);
+  }
+
+  function getTextToCopy(pupils: Pupil[] | undefined) {
+    let textToCopy = '';
+    if (pupils) {
+      const allPupils = pupils.map((pupil) => {
+        const name = pupil.name;
+        const evaluations = pupil.evaluations.map((evaluation: Evaluation) => {
+          const descriptions = evaluation.descriptions.map((description) => {
+            const value = `${description}`;
+            return value;
+          });
+          const allEvaluations = descriptions.join(' ');
+
+          return allEvaluations;
+        });
+        const joinedEvaluation = evaluations.join('\n');
+        const evaluatedPupil = `${name}\n
+        ${joinedEvaluation}`;
+        return evaluatedPupil;
+      });
+      const joinedAllPupils = allPupils.join('\n\n');
+      textToCopy = `Meine Klasse\n
+      ${joinedAllPupils}`;
+      return textToCopy;
+    } else {
+      return textToCopy;
+    }
   }
 
   return (
@@ -33,6 +64,7 @@ export default function ClassOverview(): JSX.Element {
         {pupils.map((pupil, key) => (
           <Card key={key} pupil={pupil} deleteCard={deletePupil} />
         ))}
+        {pupils.length === 0 ? '' : <CopyButton copyText={dataToCopy} />}
       </Main>
       <AddButton onClick={() => setIsFormShown(true)}>
         Schüler hinzufügen

--- a/src/app/pages/PupilOverview/PupilOverview.tsx
+++ b/src/app/pages/PupilOverview/PupilOverview.tsx
@@ -7,6 +7,7 @@ import EvaluationCard from '../../components/EvaluationCard/EvaluationCard';
 import Header from '../../components/Header/Header';
 import Navigation from '../../components/Navigation/Navigation';
 import usePupils from '../../hooks/usePupils';
+import type { Pupil } from '../../types/types';
 
 export default function PupilOverview(): JSX.Element {
   const [isFormShown, setIsFormShown] = useState(false);
@@ -14,10 +15,33 @@ export default function PupilOverview(): JSX.Element {
   const { id } = useParams<string>();
   const { addEvaluation, deleteEvaluation, findPupilById } = usePupils();
   const currentPupil = findPupilById(id);
+  const dataToCopy = getTextToCopy(currentPupil);
 
   function handleFormSubmit(pupil: { category: string; evaluation: string }) {
     addEvaluation(currentPupil, pupil.category, pupil.evaluation);
     setIsFormShown(false);
+  }
+
+  function getTextToCopy(pupil: Pupil | undefined) {
+    let textToCopy = '';
+    if (pupil) {
+      const name = pupil.name;
+      const evaluations = pupil.evaluations.map((evaluation) => {
+        const descriptions = evaluation.descriptions.map((description) => {
+          const value = `${description}`;
+          return value;
+        });
+        const allEvaluations = descriptions.join(' ');
+
+        return allEvaluations;
+      });
+      const joinedEvaluation = evaluations.join('\n');
+      textToCopy = `Beurteilung von ${name}\n
+      ${joinedEvaluation}`;
+      return textToCopy;
+    } else {
+      return textToCopy;
+    }
   }
 
   return (
@@ -48,7 +72,7 @@ export default function PupilOverview(): JSX.Element {
             ) : (
               <>
                 <Breakline />
-                <CopyButton copyText={'currentPupil'} />
+                <CopyButton copyText={dataToCopy} />
               </>
             )}
           </Main>

--- a/src/app/pages/PupilOverview/PupilOverview.tsx
+++ b/src/app/pages/PupilOverview/PupilOverview.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import styled from 'styled-components';
 import AddEvaluationForm from '../../components/AddEvaluationForm/AddEvaluationForm';
+import CopyButton from '../../components/CopyButton/CopyButton';
 import EvaluationCard from '../../components/EvaluationCard/EvaluationCard';
 import Header from '../../components/Header/Header';
 import Navigation from '../../components/Navigation/Navigation';
@@ -42,6 +43,14 @@ export default function PupilOverview(): JSX.Element {
                     onDeleteClick={deleteEvaluation}
                   />
                 ))}
+            {currentPupil.evaluations.length === 0 ? (
+              ''
+            ) : (
+              <>
+                <Breakline />
+                <CopyButton copyText={'currentPupil'} />
+              </>
+            )}
           </Main>
           <Navigation
             isFormNavigation={false}
@@ -56,6 +65,12 @@ export default function PupilOverview(): JSX.Element {
     </Container>
   );
 }
+
+const Breakline = styled.hr`
+  width: 80%;
+  border-top: 3px double var(--color-stroke);
+  height: 0.25rem;
+`;
 
 const Container = styled.div`
   height: 100vh;

--- a/src/app/pages/PupilOverview/PupilOverview.tsx
+++ b/src/app/pages/PupilOverview/PupilOverview.tsx
@@ -70,10 +70,7 @@ export default function PupilOverview(): JSX.Element {
             {currentPupil.evaluations.length === 0 ? (
               ''
             ) : (
-              <>
-                <Breakline />
-                <CopyButton copyText={dataToCopy} />
-              </>
+              <CopyButton copyText={dataToCopy} />
             )}
           </Main>
           <Navigation
@@ -89,12 +86,6 @@ export default function PupilOverview(): JSX.Element {
     </Container>
   );
 }
-
-const Breakline = styled.hr`
-  width: 80%;
-  border-top: 3px double var(--color-stroke);
-  height: 0.25rem;
-`;
 
 const Container = styled.div`
   height: 100vh;


### PR DESCRIPTION
Add CopyButton component with copyToClipboard functionality

![Bildschirmfoto 2021-12-03 um 10 21 41](https://user-images.githubusercontent.com/33567019/144578093-b1cd5f7d-9659-4590-98c5-4273671ae34c.png)

- Implement CopyButton to ClassOverview and PupilOverview
- Add function getTextToCopy (different layout depending on whether all pupils are copied or just one)

[View at heroku](https://capstone-rev-component--pjzsjv.herokuapp.com/)