### PR TITLE
Component/add evaluation form

### DIFF
--- a/src/app/GlobalStyles.tsx
+++ b/src/app/GlobalStyles.tsx
@@ -12,6 +12,7 @@ const GlobalStyles = createGlobalStyle`
         --color-text-white: #fffffe;
         --color-text-lightgreen: #abd1c6;
         --color-button: #f9bc60;
+        --color-button-hover: #f3a661;
         --color-buttonText: #001e1d;
         --color-stroke: #001e1d;
         --color-tertiary: #e16162;

--- a/src/app/components/AddEvaluationForm/AddEvaluationForm.stories.tsx
+++ b/src/app/components/AddEvaluationForm/AddEvaluationForm.stories.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import AddEvaluationForm from './AddEvaluationForm';
+
+const pupil = {
+  id: 'dhej28dhj',
+  name: {
+    first: 'Lena',
+    middle: null,
+    last: 'Beispiel',
+  },
+  evaluations: [
+    {
+      id: '28djeund',
+      category: 'Arbeitsweise',
+      descriptions: ['Lena arbeitet gut mit'],
+    },
+  ],
+};
+
+export default {
+  title: 'Component/AddEvaluationForm',
+  component: AddEvaluationForm,
+  argTypes: { onSubmit: { action: 'submitted' } },
+};
+
+export const regular = (): JSX.Element => (
+  <AddEvaluationForm
+    pupil={pupil}
+    onSubmit={() => console.log('submitted')}
+    missingInput={false}
+    onCancel={() => console.log('canceled!')}
+  />
+);

--- a/src/app/components/AddEvaluationForm/AddEvaluationForm.tsx
+++ b/src/app/components/AddEvaluationForm/AddEvaluationForm.tsx
@@ -1,0 +1,175 @@
+import React, { useState } from 'react';
+import { Rating } from 'react-simple-star-rating';
+import styled from 'styled-components';
+import type { Pupil } from '../../types/types';
+import Button from '../Button/Button';
+import Navigation from '../Navigation/Navigation';
+
+type AddEvaluationFormProps = {
+  pupil: Pupil;
+  onSubmit: (pupil: { category: string; evaluation: string }) => void;
+  onCancel: () => void;
+  missingInput: boolean;
+};
+
+export default function AddEvaluationForm({
+  pupil,
+  onSubmit,
+  onCancel,
+}: AddEvaluationFormProps): JSX.Element {
+  const [selectedCategory, setSelectedCategory] = useState('');
+  const [rating, setRating] = useState(0);
+  const [evaluation, setEvaluation] = useState('');
+  const [inputError, setInputError] = useState(false);
+  console.log(selectedCategory);
+
+  const categories = [
+    'Arbeiten in der Gruppe',
+    'Arbeitsweise',
+    'Sozialverhalten',
+    'Verhalten gegenüber dem Lehrer',
+  ];
+
+  function handleRating(rate: number) {
+    setRating(rate);
+  }
+
+  function handleCategory(category: string) {
+    setSelectedCategory(category);
+  }
+
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (selectedCategory === '' || rating === 0 || evaluation === '') {
+      setInputError(true);
+      return;
+    } else {
+      const category = selectedCategory;
+      onSubmit({ category, evaluation });
+      setInputError(false);
+      setSelectedCategory('');
+      setEvaluation('');
+    }
+  }
+
+  return (
+    <FormWrapper>
+      <FormContainer onSubmit={handleSubmit}>
+        <label htmlFor="category">Kategorie wählen:</label>
+        {categories.map((category, key) => (
+          <CategoryButton
+            key={`${category}-${key}`}
+            children={category}
+            onClick={() => handleCategory(category)}
+            type="button"
+            category={category}
+            selectedCategory={selectedCategory}
+          />
+        ))}
+
+        {inputError && selectedCategory === '' && (
+          <SubmitWarning>Bitte geben Sie eine Kategorie ein.</SubmitWarning>
+        )}
+        <label>
+          Bewertung wählen:
+          <Rating
+            onClick={handleRating}
+            ratingValue={rating}
+            size={40}
+            transition
+            fillColor={`var(--color-button)`}
+            emptyColor="gray"
+          />
+        </label>
+        {inputError && rating === 0 && (
+          <SubmitWarning>Bitte geben Sie eine Bewertung an.</SubmitWarning>
+        )}
+        <label htmlFor="evaluation">Worturteil:</label>
+        <Textarea
+          id="evaluation"
+          rows={3}
+          placeholder="Lena arbeitet häufig gut mit."
+          onChange={(event: {
+            target: { value: React.SetStateAction<string> };
+          }) => setEvaluation(event.target.value)}
+          value={evaluation}
+          missingInput={inputError}
+        />
+        {inputError && evaluation === '' && (
+          <SubmitWarning>Bitte geben Sie eine Beurteilung ein.</SubmitWarning>
+        )}
+        <Navigation navigateBack={() => onCancel()} isFormNavigation={true} />
+      </FormContainer>
+    </FormWrapper>
+  );
+}
+
+interface CategoryButton {
+  category: string;
+  selectedCategory: string;
+}
+
+const CategoryButton = styled(Button).attrs<CategoryButton>((props) => ({
+  category: props.category,
+  selectedCategory: props.selectedCategory,
+}))`
+  background: ${(props) =>
+    props.category === props.selectedCategory
+      ? 'var(--color-button-hover)'
+      : 'var(--color-button)'};
+  &:hover {
+    background: var(--color-button-hover);
+  }
+`;
+
+const FormContainer = styled.form`
+  background: var(--color-background-light);
+  color: var(--color-text-dark);
+  border: 1px solid var(--color-stroke);
+  border-radius: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  position: absolute;
+  z-index: 100;
+  font-weight: 700;
+  grid-row: 2 / 3;
+  left: 0.6rem;
+  right: 0.6rem;
+  top: 0;
+`;
+
+const FormWrapper = styled.div`
+  position: relative;
+`;
+
+const Input = styled.input<Partial<AddEvaluationFormProps>>`
+  font-family: inherit;
+  font-weight: 700;
+  background: var(--color-background-dark);
+  color: var(--color-text-white);
+  padding: 0.5rem;
+  outline: ${(props) =>
+    props.missingInput && props.value === ''
+      ? '2px solid var(--color-tertiary)'
+      : ''};
+`;
+
+const Textarea = styled.textarea<Partial<AddEvaluationFormProps>>`
+  font-family: inherit;
+  font-weight: 700;
+  background: var(--color-background-dark);
+  color: var(--color-text-white);
+  padding: 0.5rem;
+  outline: ${(props) =>
+    props.missingInput && props.value === ''
+      ? '2px solid var(--color-tertiary)'
+      : ''};
+`;
+
+const SubmitWarning = styled.span`
+  color: var(--color-tertiary);
+  text-align: center;
+`;

--- a/src/app/components/AddEvaluationForm/AddEvaluationForm.tsx
+++ b/src/app/components/AddEvaluationForm/AddEvaluationForm.tsx
@@ -97,7 +97,7 @@ export default function AddEvaluationForm({
                           onClick={() =>
                             setSelectedEvaluation(setName(description))
                           }
-                          isActive={description === selectedEvaluation}
+                          isActive={setName(description) === selectedEvaluation}
                         >
                           {setName(description)}
                         </EvaluationButton>

--- a/src/app/components/AddEvaluationForm/AddEvaluationForm.tsx
+++ b/src/app/components/AddEvaluationForm/AddEvaluationForm.tsx
@@ -24,12 +24,6 @@ export default function AddEvaluationForm({
   const [rating, setRating] = useState(0);
   const [inputError, setInputError] = useState(false);
   console.log(evaluations);
-  console.log(selectedCategory);
-
-  console.log(selectedEvaluation);
-  console.log(rating);
-
-  //const selectedEvaluation = evaluation;
 
   function handleRating(rate: number) {
     setRating(rate);
@@ -53,6 +47,10 @@ export default function AddEvaluationForm({
       setSelectedCategory('');
       setSelectedEvaluation('');
     }
+  }
+
+  function setName(description: string) {
+    return description.replace('X', pupil.name.first);
   }
 
   return (
@@ -96,10 +94,12 @@ export default function AddEvaluationForm({
                         <EvaluationButton
                           key={`${description}-${key}`}
                           type="button"
-                          onClick={() => setSelectedEvaluation(description)}
+                          onClick={() =>
+                            setSelectedEvaluation(setName(description))
+                          }
                           isActive={description === selectedEvaluation}
                         >
-                          {description}
+                          {setName(description)}
                         </EvaluationButton>
                       ))
                     : ''

--- a/src/app/components/AddEvaluationForm/AddEvaluationForm.tsx
+++ b/src/app/components/AddEvaluationForm/AddEvaluationForm.tsx
@@ -21,12 +21,11 @@ export default function AddEvaluationForm({
   const { evaluations } = useEvaluations();
   const [selectedCategory, setSelectedCategory] = useState('');
   const [selectedEvaluation, setSelectedEvaluation] = useState('');
-  const [rating, setRating] = useState(0);
+  const [selectedRating, setSelectedRating] = useState(0);
   const [inputError, setInputError] = useState(false);
-  console.log(evaluations);
 
   function handleRating(rate: number) {
-    setRating(rate);
+    setSelectedRating(rate);
   }
 
   function handleCategory(category: string) {
@@ -36,17 +35,21 @@ export default function AddEvaluationForm({
   function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
-    if (selectedCategory === '' || rating === 0 || selectedEvaluation === '') {
+    if (
+      selectedCategory === '' ||
+      selectedRating === 0 ||
+      selectedEvaluation === ''
+    ) {
       setInputError(true);
       return;
-    } else {
-      const category = selectedCategory;
-      const evaluation = selectedEvaluation;
-      onSubmit(category, evaluation);
-      setInputError(false);
-      setSelectedCategory('');
-      setSelectedEvaluation('');
     }
+    const category = selectedCategory;
+    const evaluation = selectedEvaluation;
+    onSubmit(category, evaluation);
+    setInputError(false);
+    setSelectedCategory('');
+    setSelectedEvaluation('');
+    setSelectedRating(0);
   }
 
   function setName(description: string) {
@@ -74,23 +77,23 @@ export default function AddEvaluationForm({
         <label>Bewertung wählen:</label>
         <Rating
           onClick={handleRating}
-          ratingValue={rating}
+          ratingValue={selectedRating}
           size={40}
           transition
           fillColor={`var(--color-button)`}
           emptyColor="gray"
         />
 
-        {inputError && rating === 0 && (
+        {inputError && selectedRating === 0 && (
           <SubmitWarning>Bitte geben Sie eine Bewertung an.</SubmitWarning>
         )}
         <label htmlFor="evaluation">Worturteil:</label>
         {selectedCategory &&
           evaluations.map((evaluation) =>
             evaluation.name === selectedCategory
-              ? evaluation.evaluations.map((evaluation) =>
-                  evaluation.mark === rating
-                    ? evaluation.descriptions.map((description, key) => (
+              ? evaluation.valuations.map((valuation) =>
+                  valuation.mark === selectedRating
+                    ? valuation.descriptions.map((description, key) => (
                         <EvaluationButton
                           key={`${description}-${key}`}
                           type="button"

--- a/src/app/components/AddEvaluationForm/AddEvaluationForm.tsx
+++ b/src/app/components/AddEvaluationForm/AddEvaluationForm.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import type { Pupil } from '../../types/types';
 import Button from '../Button/Button';
 import Navigation from '../Navigation/Navigation';
+import defaultEvaluations from '../utils/DefaultEvaluations';
 
 type AddEvaluationFormProps = {
   pupil: Pupil;
@@ -17,18 +18,16 @@ export default function AddEvaluationForm({
   onSubmit,
   onCancel,
 }: AddEvaluationFormProps): JSX.Element {
+  const standardEvaluations = defaultEvaluations;
   const [selectedCategory, setSelectedCategory] = useState('');
   const [rating, setRating] = useState(0);
   const [evaluation, setEvaluation] = useState('');
   const [inputError, setInputError] = useState(false);
   console.log(selectedCategory);
+  console.log(standardEvaluations);
+  console.log(evaluation);
 
-  const categories = [
-    'Arbeiten in der Gruppe',
-    'Arbeitsweise',
-    'Sozialverhalten',
-    'Verhalten gegenüber dem Lehrer',
-  ];
+  const selectedEvaluation = evaluation;
 
   function handleRating(rate: number) {
     setRating(rate);
@@ -57,13 +56,13 @@ export default function AddEvaluationForm({
     <FormWrapper>
       <FormContainer onSubmit={handleSubmit}>
         <label htmlFor="category">Kategorie wählen:</label>
-        {categories.map((category, key) => (
+        {standardEvaluations.map((evaluation, key) => (
           <CategoryButton
-            key={`${category}-${key}`}
-            children={category}
-            onClick={() => handleCategory(category)}
+            key={`${evaluation.name}-${key}`}
+            children={evaluation.name}
+            onClick={() => handleCategory(evaluation.name)}
             type="button"
-            category={category}
+            category={evaluation.name}
             selectedCategory={selectedCategory}
           />
         ))}
@@ -86,7 +85,27 @@ export default function AddEvaluationForm({
           <SubmitWarning>Bitte geben Sie eine Bewertung an.</SubmitWarning>
         )}
         <label htmlFor="evaluation">Worturteil:</label>
-        <Textarea
+        {selectedCategory &&
+          standardEvaluations.map((evaluation) =>
+            evaluation.name === selectedCategory
+              ? evaluation.evaluations.map((evaluation) =>
+                  evaluation.mark === rating
+                    ? evaluation.descriptions.map((description, key) => (
+                        <EvaluationButton
+                          key={`${description}-${key}`}
+                          type="button"
+                          onClick={() => setEvaluation(description)}
+                          description={description}
+                          selectedDescription={selectedEvaluation}
+                        >
+                          {description}
+                        </EvaluationButton>
+                      ))
+                    : ''
+                )
+              : ''
+          )}
+        {/* <Textarea
           id="evaluation"
           rows={3}
           placeholder="Lena arbeitet häufig gut mit."
@@ -95,7 +114,7 @@ export default function AddEvaluationForm({
           }) => setEvaluation(event.target.value)}
           value={evaluation}
           missingInput={inputError}
-        />
+        /> */}
         {inputError && evaluation === '' && (
           <SubmitWarning>Bitte geben Sie eine Beurteilung ein.</SubmitWarning>
         )}
@@ -110,6 +129,11 @@ interface CategoryButton {
   selectedCategory: string;
 }
 
+interface EvaluationButton {
+  description: string;
+  selectedDescription: string;
+}
+
 const CategoryButton = styled(Button).attrs<CategoryButton>((props) => ({
   category: props.category,
   selectedCategory: props.selectedCategory,
@@ -120,6 +144,20 @@ const CategoryButton = styled(Button).attrs<CategoryButton>((props) => ({
       : 'var(--color-button)'};
   &:hover {
     background: var(--color-button-hover);
+  }
+`;
+
+const EvaluationButton = styled.button.attrs<EvaluationButton>((props) => ({
+  description: props.description,
+  selectedDescription: props.selectedDescription,
+}))`
+  background: inherit;
+  color: inherit;
+  border: none;
+  font-weight: ${(props) =>
+    props.description === props.selectedDescription ? '800' : '400'};
+  &:hover {
+    font-weight: 800;
   }
 `;
 
@@ -143,18 +181,6 @@ const FormContainer = styled.form`
 
 const FormWrapper = styled.div`
   position: relative;
-`;
-
-const Input = styled.input<Partial<AddEvaluationFormProps>>`
-  font-family: inherit;
-  font-weight: 700;
-  background: var(--color-background-dark);
-  color: var(--color-text-white);
-  padding: 0.5rem;
-  outline: ${(props) =>
-    props.missingInput && props.value === ''
-      ? '2px solid var(--color-tertiary)'
-      : ''};
 `;
 
 const Textarea = styled.textarea<Partial<AddEvaluationFormProps>>`

--- a/src/app/components/Button/Button.tsx
+++ b/src/app/components/Button/Button.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 
 type ButtonProps = {
   children: ReactNode;
-  onClick?: () => void;
   category?: string;
   selectedCategory?: string;
 };

--- a/src/app/components/Button/Button.tsx
+++ b/src/app/components/Button/Button.tsx
@@ -4,6 +4,8 @@ import styled from 'styled-components';
 type ButtonProps = {
   children: ReactNode;
   onClick?: () => void;
+  category?: string;
+  selectedCategory?: string;
 };
 
 const Button = styled.button<ButtonProps>`

--- a/src/app/components/utils/DefaultEvaluations.ts
+++ b/src/app/components/utils/DefaultEvaluations.ts
@@ -1,0 +1,164 @@
+const defaultEvaluations = [
+  {
+    name: 'Arbeiten in der Gruppe',
+    evaluations: [
+      {
+        mark: 20,
+        descriptions: [
+          `Es gelang ${name} nicht immer sich mit seinen Mitschülern zu verständigen, ohne dass dies zu Konflikten führte.`,
+          `${name} war nur selten bereit Aufgaben in der Klasse zu übernehmen oder bei deren Durchführung mitzuwirken.`,
+        ],
+      },
+      {
+        mark: 40,
+        descriptions: [
+          `${name} arbeitete ungern mit anderen zusammen und musste häufig zur Beteiligung ermahnt werden.`,
+          `Ma${name} hielt sich bei gemeinschaftlichen Aufgaben zurück und wartete ab, bis er von anderen in die Aktivitäten eingebunden wurde.`,
+        ],
+      },
+      {
+        mark: 60,
+        descriptions: [
+          `${name} arbeitete bereitwillig in der Gruppe mit, versuchte jedoch Führungsaufgaben zu vermeiden und wollte sich lieber im Hintergrund halten.`,
+          `${name} war bemüht zu kooperieren.`,
+        ],
+      },
+      {
+        mark: 80,
+        descriptions: [
+          `${name} arbeitete produktiv in einer Gruppe mit.`,
+          `Bereitwillig und verantwortungsbewusst übernahm ${name} Dienste in der Klassengemeinschaft.`,
+        ],
+      },
+      {
+        mark: 100,
+        descriptions: [
+          `${name} arbeitete sehr gerne mit anderen in der Gruppe zusammen und übernahm bereitwillig die Führungsaufgaben.`,
+          `Zuverlässig, kameradschaftlich und mit kreativen Ideen brachte sich Ma${name} in gemeinschaftliche Aufgaben ein.`,
+        ],
+      },
+    ],
+  },
+  {
+    name: 'Arbeitsweise',
+    evaluations: [
+      {
+        mark: 20,
+        descriptions: [
+          `${name} beteiligte sich nur sehr selten am Unterrichtsgeschehen und wirkte in den meisten Fällen sehr desinteressiert.`,
+          `${name} beteiligte sich noch zu wenig am Unterrichtsgespräch.`,
+        ],
+      },
+      {
+        mark: 40,
+        descriptions: [
+          `Am Unterricht beteiligte ${name} sich meist mit wenig Ausdauer.`,
+          `${name} verfolgte das Unterrichtsgeschehen mit wechselndem Interesse.`,
+        ],
+      },
+      {
+        mark: 60,
+        descriptions: [
+          `${name} folgte überwiegend aufmerksam dem Unterrichtsgeschehen.`,
+          `${name} bemühte sich, dem Unterricht aufmerksam zu folgen. Oft ließ er sich noch ablenken und verpasste Zusammenhänge.`,
+        ],
+      },
+      {
+        mark: 80,
+        descriptions: [
+          `Immer dann, wenn ${name} sich auf die Aufgabenstellungen konzentrierte und nicht ablenken ließ, erreichte er sehr gute Ergebnisse.`,
+          `${name} zeigte großes Interesse und meist sicheres Urteilsvermögen.`,
+        ],
+      },
+      {
+        mark: 100,
+        descriptions: [
+          `Mit beachtlichem Fleiß gelangen ${name} herausragende Ergebnisse.`,
+          `Neue Aufträge ging ${name} rasch und zielstrebig an.`,
+        ],
+      },
+    ],
+  },
+  {
+    name: 'Sozialverhalten',
+    evaluations: [
+      {
+        mark: 20,
+        descriptions: [
+          `Das Betragen von ${name} gab oft Anlass zu Kritik, die jedoch nicht ausreichend Beachtung fand.`,
+          `Es gelang ${name} immer noch nicht sich mit seinen Mitschülern zu verständigen, ohne dass dies zu ernsteren Konflikten führte.`,
+        ],
+      },
+      {
+        mark: 40,
+        descriptions: [
+          `${name} könnte durch aktiveres Auftreten in der Klassengemeinschaft und Beteiligung an Konfliktlösungen seine Anerkennung bei Mitschülern steigern.`,
+          `Es fiel ihm meist schwer, eigene Bedürfnisse und Interessen zurückzustellen.`,
+        ],
+      },
+      {
+        mark: 60,
+        descriptions: [
+          `${name} war sehr kontaktfreudig und fügte sich meist gut in die Klassengemeinschaft ein.`,
+          `Es fiel ${name} nicht leicht, sich in die Lage anderer einzufühlen.`,
+        ],
+      },
+      {
+        mark: 80,
+        descriptions: [
+          `${name} trat freundlich und aufgeschlossen auf, war kontaktfreudig und mitteilsam.`,
+          `${name} verstand sich gut mit seinen Mitschülern.`,
+        ],
+      },
+      {
+        mark: 100,
+        descriptions: [
+          `${name} trat ruhig und höflich auf, äußerte sich gut durchdacht und bereicherte das Klassenklima.`,
+          `${name} gefiel durch immer einwandfreies Verhalten und große Einsatzbereitschaft für die Gemeinschaft.`,
+        ],
+      },
+    ],
+  },
+  {
+    name: 'Verhalten gegenüber dem Lehrer',
+    evaluations: [
+      {
+        mark: 20,
+        descriptions: [
+          `Zuweilen fiel es ${name} nicht leicht, gegenüber seinen Lehrkräften einen angemessenen Ton zu finden.`,
+          `Ratschläge und Hilfestellungen von Lehrkräften akzeptierte ${name} nur selten.`,
+        ],
+      },
+      {
+        mark: 40,
+        descriptions: [
+          `Zuweilen beachtete ${name} die Umgangsformen gegenüber den Lehrkräften nicht.`,
+          `Den Lehrkräften gegenüber gab sich ${name} sehr zurückhaltend, schüchtern und gehemmt.`,
+        ],
+      },
+      {
+        mark: 60,
+        descriptions: [
+          `Auf Hinweise oder Hilfen durch Lehrer reagierte ${name} meist angemessen und respektvoll.`,
+          `${name} verhielt sich freundlich und kooperativ, war jedoch noch recht zurückhaltend.`,
+        ],
+      },
+      {
+        mark: 80,
+        descriptions: [
+          `${name} verhielt sich Lehrern gegenüber stets höflich und war bei seinen Mitschülern beliebt.`,
+          `${name} suchte selbstständig und regelmäßig Kontakt zu den Lehrern.`,
+        ],
+      },
+      {
+        mark: 100,
+        descriptions: [
+          `Oft erfragte ${name} beim Lehrer Rat und suchte auch gerne persönlichen Kontakt.`,
+          `Hinweise des Lehrers nahm ${name} interessiert und freundlich auf.`,
+        ],
+      },
+    ],
+  },
+];
+
+export default defaultEvaluations;

--- a/src/app/components/utils/DefaultEvaluations.ts
+++ b/src/app/components/utils/DefaultEvaluations.ts
@@ -1,7 +1,7 @@
 const defaultEvaluations = [
   {
     name: 'Arbeiten in der Gruppe',
-    evaluations: [
+    valuations: [
       {
         mark: 20,
         descriptions: [
@@ -41,7 +41,7 @@ const defaultEvaluations = [
   },
   {
     name: 'Arbeitsweise',
-    evaluations: [
+    valuations: [
       {
         mark: 20,
         descriptions: [
@@ -81,7 +81,7 @@ const defaultEvaluations = [
   },
   {
     name: 'Sozialverhalten',
-    evaluations: [
+    valuations: [
       {
         mark: 20,
         descriptions: [
@@ -121,7 +121,7 @@ const defaultEvaluations = [
   },
   {
     name: 'Verhalten gegenüber dem Lehrer',
-    evaluations: [
+    valuations: [
       {
         mark: 20,
         descriptions: [

--- a/src/app/components/utils/DefaultEvaluations.ts
+++ b/src/app/components/utils/DefaultEvaluations.ts
@@ -5,36 +5,36 @@ const defaultEvaluations = [
       {
         mark: 20,
         descriptions: [
-          `Es gelang ${name} nicht immer sich mit seinen Mitschülern zu verständigen, ohne dass dies zu Konflikten führte.`,
-          `${name} war nur selten bereit Aufgaben in der Klasse zu übernehmen oder bei deren Durchführung mitzuwirken.`,
+          `Es gelang X nicht immer sich mit seinen Mitschülern zu verständigen, ohne dass dies zu Konflikten führte.`,
+          `X war nur selten bereit Aufgaben in der Klasse zu übernehmen oder bei deren Durchführung mitzuwirken.`,
         ],
       },
       {
         mark: 40,
         descriptions: [
-          `${name} arbeitete ungern mit anderen zusammen und musste häufig zur Beteiligung ermahnt werden.`,
-          `Ma${name} hielt sich bei gemeinschaftlichen Aufgaben zurück und wartete ab, bis er von anderen in die Aktivitäten eingebunden wurde.`,
+          `X arbeitete ungern mit anderen zusammen und musste häufig zur Beteiligung ermahnt werden.`,
+          `MaX hielt sich bei gemeinschaftlichen Aufgaben zurück und wartete ab, bis er von anderen in die Aktivitäten eingebunden wurde.`,
         ],
       },
       {
         mark: 60,
         descriptions: [
-          `${name} arbeitete bereitwillig in der Gruppe mit, versuchte jedoch Führungsaufgaben zu vermeiden und wollte sich lieber im Hintergrund halten.`,
-          `${name} war bemüht zu kooperieren.`,
+          `X arbeitete bereitwillig in der Gruppe mit, versuchte jedoch Führungsaufgaben zu vermeiden und wollte sich lieber im Hintergrund halten.`,
+          `X war bemüht zu kooperieren.`,
         ],
       },
       {
         mark: 80,
         descriptions: [
-          `${name} arbeitete produktiv in einer Gruppe mit.`,
-          `Bereitwillig und verantwortungsbewusst übernahm ${name} Dienste in der Klassengemeinschaft.`,
+          `X arbeitete produktiv in einer Gruppe mit.`,
+          `Bereitwillig und verantwortungsbewusst übernahm X Dienste in der Klassengemeinschaft.`,
         ],
       },
       {
         mark: 100,
         descriptions: [
-          `${name} arbeitete sehr gerne mit anderen in der Gruppe zusammen und übernahm bereitwillig die Führungsaufgaben.`,
-          `Zuverlässig, kameradschaftlich und mit kreativen Ideen brachte sich Ma${name} in gemeinschaftliche Aufgaben ein.`,
+          `X arbeitete sehr gerne mit anderen in der Gruppe zusammen und übernahm bereitwillig die Führungsaufgaben.`,
+          `Zuverlässig, kameradschaftlich und mit kreativen Ideen brachte sich X in gemeinschaftliche Aufgaben ein.`,
         ],
       },
     ],
@@ -45,36 +45,36 @@ const defaultEvaluations = [
       {
         mark: 20,
         descriptions: [
-          `${name} beteiligte sich nur sehr selten am Unterrichtsgeschehen und wirkte in den meisten Fällen sehr desinteressiert.`,
-          `${name} beteiligte sich noch zu wenig am Unterrichtsgespräch.`,
+          `X beteiligte sich nur sehr selten am Unterrichtsgeschehen und wirkte in den meisten Fällen sehr desinteressiert.`,
+          `X beteiligte sich noch zu wenig am Unterrichtsgespräch.`,
         ],
       },
       {
         mark: 40,
         descriptions: [
-          `Am Unterricht beteiligte ${name} sich meist mit wenig Ausdauer.`,
-          `${name} verfolgte das Unterrichtsgeschehen mit wechselndem Interesse.`,
+          `Am Unterricht beteiligte X sich meist mit wenig Ausdauer.`,
+          `X verfolgte das Unterrichtsgeschehen mit wechselndem Interesse.`,
         ],
       },
       {
         mark: 60,
         descriptions: [
-          `${name} folgte überwiegend aufmerksam dem Unterrichtsgeschehen.`,
-          `${name} bemühte sich, dem Unterricht aufmerksam zu folgen. Oft ließ er sich noch ablenken und verpasste Zusammenhänge.`,
+          `X folgte überwiegend aufmerksam dem Unterrichtsgeschehen.`,
+          `X bemühte sich, dem Unterricht aufmerksam zu folgen. Oft ließ er sich noch ablenken und verpasste Zusammenhänge.`,
         ],
       },
       {
         mark: 80,
         descriptions: [
-          `Immer dann, wenn ${name} sich auf die Aufgabenstellungen konzentrierte und nicht ablenken ließ, erreichte er sehr gute Ergebnisse.`,
-          `${name} zeigte großes Interesse und meist sicheres Urteilsvermögen.`,
+          `Immer dann, wenn X sich auf die Aufgabenstellungen konzentrierte und nicht ablenken ließ, erreichte er sehr gute Ergebnisse.`,
+          `X zeigte großes Interesse und meist sicheres Urteilsvermögen.`,
         ],
       },
       {
         mark: 100,
         descriptions: [
-          `Mit beachtlichem Fleiß gelangen ${name} herausragende Ergebnisse.`,
-          `Neue Aufträge ging ${name} rasch und zielstrebig an.`,
+          `Mit beachtlichem Fleiß gelangen X herausragende Ergebnisse.`,
+          `Neue Aufträge ging X rasch und zielstrebig an.`,
         ],
       },
     ],
@@ -85,36 +85,36 @@ const defaultEvaluations = [
       {
         mark: 20,
         descriptions: [
-          `Das Betragen von ${name} gab oft Anlass zu Kritik, die jedoch nicht ausreichend Beachtung fand.`,
-          `Es gelang ${name} immer noch nicht sich mit seinen Mitschülern zu verständigen, ohne dass dies zu ernsteren Konflikten führte.`,
+          `Das Betragen von X gab oft Anlass zu Kritik, die jedoch nicht ausreichend Beachtung fand.`,
+          `Es gelang X immer noch nicht sich mit seinen Mitschülern zu verständigen, ohne dass dies zu ernsteren Konflikten führte.`,
         ],
       },
       {
         mark: 40,
         descriptions: [
-          `${name} könnte durch aktiveres Auftreten in der Klassengemeinschaft und Beteiligung an Konfliktlösungen seine Anerkennung bei Mitschülern steigern.`,
+          `X könnte durch aktiveres Auftreten in der Klassengemeinschaft und Beteiligung an Konfliktlösungen seine Anerkennung bei Mitschülern steigern.`,
           `Es fiel ihm meist schwer, eigene Bedürfnisse und Interessen zurückzustellen.`,
         ],
       },
       {
         mark: 60,
         descriptions: [
-          `${name} war sehr kontaktfreudig und fügte sich meist gut in die Klassengemeinschaft ein.`,
-          `Es fiel ${name} nicht leicht, sich in die Lage anderer einzufühlen.`,
+          `X war sehr kontaktfreudig und fügte sich meist gut in die Klassengemeinschaft ein.`,
+          `Es fiel X nicht leicht, sich in die Lage anderer einzufühlen.`,
         ],
       },
       {
         mark: 80,
         descriptions: [
-          `${name} trat freundlich und aufgeschlossen auf, war kontaktfreudig und mitteilsam.`,
-          `${name} verstand sich gut mit seinen Mitschülern.`,
+          `X trat freundlich und aufgeschlossen auf, war kontaktfreudig und mitteilsam.`,
+          `X verstand sich gut mit seinen Mitschülern.`,
         ],
       },
       {
         mark: 100,
         descriptions: [
-          `${name} trat ruhig und höflich auf, äußerte sich gut durchdacht und bereicherte das Klassenklima.`,
-          `${name} gefiel durch immer einwandfreies Verhalten und große Einsatzbereitschaft für die Gemeinschaft.`,
+          `X trat ruhig und höflich auf, äußerte sich gut durchdacht und bereicherte das Klassenklima.`,
+          `X gefiel durch immer einwandfreies Verhalten und große Einsatzbereitschaft für die Gemeinschaft.`,
         ],
       },
     ],
@@ -125,36 +125,36 @@ const defaultEvaluations = [
       {
         mark: 20,
         descriptions: [
-          `Zuweilen fiel es ${name} nicht leicht, gegenüber seinen Lehrkräften einen angemessenen Ton zu finden.`,
-          `Ratschläge und Hilfestellungen von Lehrkräften akzeptierte ${name} nur selten.`,
+          `Zuweilen fiel es X nicht leicht, gegenüber seinen Lehrkräften einen angemessenen Ton zu finden.`,
+          `Ratschläge und Hilfestellungen von Lehrkräften akzeptierte X nur selten.`,
         ],
       },
       {
         mark: 40,
         descriptions: [
-          `Zuweilen beachtete ${name} die Umgangsformen gegenüber den Lehrkräften nicht.`,
-          `Den Lehrkräften gegenüber gab sich ${name} sehr zurückhaltend, schüchtern und gehemmt.`,
+          `Zuweilen beachtete X die Umgangsformen gegenüber den Lehrkräften nicht.`,
+          `Den Lehrkräften gegenüber gab sich X sehr zurückhaltend, schüchtern und gehemmt.`,
         ],
       },
       {
         mark: 60,
         descriptions: [
-          `Auf Hinweise oder Hilfen durch Lehrer reagierte ${name} meist angemessen und respektvoll.`,
-          `${name} verhielt sich freundlich und kooperativ, war jedoch noch recht zurückhaltend.`,
+          `Auf Hinweise oder Hilfen durch Lehrer reagierte X meist angemessen und respektvoll.`,
+          `X verhielt sich freundlich und kooperativ, war jedoch noch recht zurückhaltend.`,
         ],
       },
       {
         mark: 80,
         descriptions: [
-          `${name} verhielt sich Lehrern gegenüber stets höflich und war bei seinen Mitschülern beliebt.`,
-          `${name} suchte selbstständig und regelmäßig Kontakt zu den Lehrern.`,
+          `X verhielt sich Lehrern gegenüber stets höflich und war bei seinen Mitschülern beliebt.`,
+          `X suchte selbstständig und regelmäßig Kontakt zu den Lehrern.`,
         ],
       },
       {
         mark: 100,
         descriptions: [
-          `Oft erfragte ${name} beim Lehrer Rat und suchte auch gerne persönlichen Kontakt.`,
-          `Hinweise des Lehrers nahm ${name} interessiert und freundlich auf.`,
+          `Oft erfragte X beim Lehrer Rat und suchte auch gerne persönlichen Kontakt.`,
+          `Hinweise des Lehrers nahm X interessiert und freundlich auf.`,
         ],
       },
     ],

--- a/src/app/hooks/useEvaluations.ts
+++ b/src/app/hooks/useEvaluations.ts
@@ -1,0 +1,13 @@
+import defaultEvaluations from '../components/utils/DefaultEvaluations';
+import type { DefaultEvaluation } from '../types/types';
+import useLocalStorage from './useLocalStorage';
+
+export default function useEvaluations(): {
+  evaluations: DefaultEvaluation[];
+} {
+  const [evaluations] = useLocalStorage<DefaultEvaluation[]>(
+    'defaultEvaluations',
+    defaultEvaluations
+  );
+  return { evaluations };
+}

--- a/src/app/pages/PupilOverview/PupilOverview.tsx
+++ b/src/app/pages/PupilOverview/PupilOverview.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import styled from 'styled-components';
-import AddEvaluationForm from '../../components/AddCategoryForm/AddCategoryForm';
+import AddEvaluationForm from '../../components/AddEvaluationForm/AddEvaluationForm';
 import CopyButton from '../../components/CopyButton/CopyButton';
 import EvaluationCard from '../../components/EvaluationCard/EvaluationCard';
 import Header from '../../components/Header/Header';
@@ -52,6 +52,7 @@ export default function PupilOverview(): JSX.Element {
           <Main>
             {isFormShown && (
               <AddEvaluationForm
+                pupil={currentPupil}
                 onSubmit={handleFormSubmit}
                 missingInput={false}
                 onCancel={() => setIsFormShown(false)}

--- a/src/app/pages/PupilOverview/PupilOverview.tsx
+++ b/src/app/pages/PupilOverview/PupilOverview.tsx
@@ -17,8 +17,8 @@ export default function PupilOverview(): JSX.Element {
   const currentPupil = findPupilById(id);
   const dataToCopy = getTextToCopy(currentPupil);
 
-  function handleFormSubmit(pupil: { category: string; evaluation: string }) {
-    addEvaluation(currentPupil, pupil.category, pupil.evaluation);
+  function handleFormSubmit(category: string, evaluation: string) {
+    addEvaluation(currentPupil, category, evaluation);
     setIsFormShown(false);
   }
 

--- a/src/app/types/types.ts
+++ b/src/app/types/types.ts
@@ -1,12 +1,12 @@
 export type DefaultEvaluation = {
   name: string;
-  evaluations: { mark: number; descriptions: string[] }[];
+  valuations: { mark: number; descriptions: string[] }[];
 };
 
 export type DefaultEvaluations = [
   {
     name: string;
-    evaluations: [
+    valuations: [
       {
         mark: number;
         descriptions: string[];

--- a/src/app/types/types.ts
+++ b/src/app/types/types.ts
@@ -1,3 +1,20 @@
+export type DefaultEvaluation = {
+  name: string;
+  evaluations: { mark: number; descriptions: string[] }[];
+};
+
+export type DefaultEvaluations = [
+  {
+    name: string;
+    evaluations: [
+      {
+        mark: number;
+        descriptions: string[];
+      }
+    ];
+  }
+];
+
 export type Evaluation = {
   id: string;
   category: string;


### PR DESCRIPTION
Refactor evaluations: added now by choice of rating and phrase

![Bildschirmfoto 2021-12-07 um 16 31 08](https://user-images.githubusercontent.com/33567019/145058410-24a1cff5-48fa-4779-b73b-1b86f800f0f0.png)

- Add button hover and active colour
- Add defaultEvaluations in categories and 5 marks
- Add basic useEvaluation.ts for localStorage usage
- In PupilOverview, you can add a evaluation by choosing the category, rating and a prompted phrase.


Hint: I focused on the AddEvaluationForm component; when adding a pupil, you can still add a category and evaluation by writing - this will be removed in the next PR.

[View at heroku](https://capstone-rev-component--kgk8zr.herokuapp.com/)